### PR TITLE
Add support for PyQt5 (+untested PySide) via shim qt.py

### DIFF
--- a/qutepart/__init__.py
+++ b/qutepart/__init__.py
@@ -6,13 +6,14 @@ import os.path
 import logging
 import platform
 
-from PyQt4.QtCore import QRect, Qt, pyqtSignal
-from PyQt4.QtGui import QAction, QApplication, QColor, QBrush, \
+from qutepart.qt import QRect, Qt, pyqtSignal
+from qutepart.qt import QApplication, QPlainTextEdit, QTextEdit
+from qutepart.qt import QAction, QColor, QBrush, \
                         QDialog, QFont, \
                         QIcon, QKeySequence, QPainter, QPen, QPalette, \
-                        QPlainTextEdit, \
-                        QPrintDialog, QTextCharFormat, QTextCursor, \
-                        QTextBlock, QTextEdit, QTextFormat
+                        QTextCharFormat, QTextCursor, \
+                        QTextBlock, QTextFormat
+from qutepart.qt import QPrintDialog
 
 from qutepart.syntax import SyntaxManager
 from qutepart.syntaxhlighter import SyntaxHighlighter

--- a/qutepart/bookmarks.py
+++ b/qutepart/bookmarks.py
@@ -1,7 +1,7 @@
 """Bookmarks functionality implementation"""
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import QAction, QIcon, QKeySequence, QTextCursor
+from qutepart.qt import Qt
+from qutepart.qt import QAction, QIcon, QKeySequence, QTextCursor
 
 import qutepart
 

--- a/qutepart/brackethlighter.py
+++ b/qutepart/brackethlighter.py
@@ -4,8 +4,9 @@ Calculates list of QTextEdit.ExtraSelection
 
 import time
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import QTextCursor, QTextEdit
+from qutepart.qt import Qt
+from qutepart.qt import QTextEdit
+from qutepart.qt import QTextCursor
 
 
 class _TimeoutException(UserWarning):

--- a/qutepart/completer.py
+++ b/qutepart/completer.py
@@ -4,8 +4,9 @@
 import re
 import time
 
-from PyQt4.QtCore import pyqtSignal, QAbstractItemModel, QEvent, QModelIndex, QObject, QSize, Qt, QTimer, Qt
-from PyQt4.QtGui import QCursor, QListView, QStyle
+from qutepart.qt import pyqtSignal, QAbstractItemModel, QEvent, QModelIndex, QObject, QSize, Qt, QTimer, Qt
+from qutepart.qt import QListView
+from qutepart.qt import QCursor, QStyle
 
 from qutepart.htmldelegate import HTMLDelegate
 

--- a/qutepart/htmldelegate.py
+++ b/qutepart/htmldelegate.py
@@ -3,10 +3,11 @@ htmldelegate --- QStyledItemDelegate delegate. Draws HTML
 =========================================================
 """
 
-from PyQt4.QtGui import QApplication, QAbstractTextDocumentLayout, \
-                        QStyledItemDelegate, QStyle, QStyleOptionViewItemV4, \
-                        QTextDocument, QPalette
-from PyQt4.QtCore import QSize
+from qutepart.qt import QAbstractTextDocumentLayout, \
+                        QStyledItemDelegate, QStyle, QStyleOptionViewItem, \
+                        QPalette
+from qutepart.qt import QApplication, QTextDocument
+from qutepart.qt import QSize
 
 _HTML_ESCAPE_TABLE = \
 {
@@ -37,7 +38,7 @@ class HTMLDelegate(QStyledItemDelegate):
         """
         option.state &= ~QStyle.State_HasFocus  # never draw focus rect
 
-        options = QStyleOptionViewItemV4(option)
+        options = QStyleOptionViewItem(option)
         self.initStyleOption(options,index)
 
         style = QApplication.style() if options.widget is None else options.widget.style()
@@ -72,7 +73,7 @@ class HTMLDelegate(QStyledItemDelegate):
     def sizeHint(self, option, index):
         """QStyledItemDelegate.sizeHint implementation
         """
-        options = QStyleOptionViewItemV4(option)
+        options = QStyleOptionViewItem(option)
         self.initStyleOption(options,index)
 
         doc = QTextDocument()

--- a/qutepart/indenter/__init__.py
+++ b/qutepart/indenter/__init__.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger('qutepart')
 
 
-from PyQt4.QtGui import QTextCursor
+from qutepart.qt import QTextCursor
 
 
 def _getSmartIndenter(indenterName, qpart, indenter):

--- a/qutepart/lines.py
+++ b/qutepart/lines.py
@@ -2,7 +2,7 @@
 list-like object for access text document lines
 """
 
-from PyQt4.QtGui import QTextCursor
+from qutepart.qt import QTextCursor
 
 
 def _iterateBlocksFrom(block):

--- a/qutepart/qt.py
+++ b/qutepart/qt.py
@@ -1,0 +1,85 @@
+from __future__ import unicode_literals
+import sys
+import os
+
+PYSIDE = 0
+PYQT4 = 1
+PYQT5 = 2
+
+USE_QT_PY = None
+
+QT_API_ENV = os.environ.get('QT_API')
+ETS = dict(pyqt=PYQT4, pyqt5=PYQT5, pyside=PYSIDE)
+
+# Check environment variable
+if QT_API_ENV and QT_API_ENV in ETS:
+    USE_QT_PY = ETS[QT_API_ENV]
+
+# Check if one already importer
+elif 'PyQt4' in sys.modules:
+    USE_QT_PY = PYQT4
+elif 'PyQt5' in sys.modules:
+    USE_QT_PY = PYQT5
+else:
+    # Try importing in turn
+    try:
+        import PyQt5
+        USE_QT_PY = PYQT5
+    except:
+        try:
+            import PyQt4
+            USE_QT_PY = PYQT4
+        except ImportError:
+            try:
+                import PySide
+                USE_QT_PY = PYSIDE
+            except:
+                pass
+
+# Import PyQt classes accessible in elsewhere through from qt import *
+if USE_QT_PY == PYQT5:
+    from PyQt5.QtGui import *
+    from PyQt5.QtCore import *
+    from PyQt5.QtWebKit import *
+    from PyQt5.QtNetwork import *
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtWebKitWidgets import *
+    from PyQt5.QtPrintSupport import *
+    from PyQt5.QtTest import *
+    
+    # qWaitForWindowShown is not provided in Qt5; see bug: https://bugreports.qt-project.org/browse/QTBUG-23185
+    QTest.qWaitForWindowShown = QTest.qWaitForWindowActive
+
+elif USE_QT_PY == PYSIDE:
+    from PySide.QtGui import *
+    from PySide.QtCore import *
+    from PySide.QtNetwork import *
+    from PySide.QtTest import *
+
+    pyqtSignal = Signal
+
+elif USE_QT_PY == PYQT4:
+
+    import sip
+    sip.setapi('QString', 2)
+    sip.setapi('QVariant', 2)
+
+    from PyQt4.QtGui import *
+    from PyQt4.QtCore import *
+    from PyQt4.QtWebKit import *
+    from PyQt4.QtNetwork import *
+    from PyQt4.QtTest import *
+
+    QFileDialog.getOpenFileName_ = QFileDialog.getOpenFileName
+    QFileDialog.getSaveFileName_ = QFileDialog.getSaveFileName
+
+    class QFileDialog(QFileDialog):
+        @staticmethod
+        def getOpenFileName(*args, **kwargs):
+            return QFileDialog.getOpenFileName_(*args, **kwargs), None
+
+        @staticmethod
+        def getSaveFileName(*args, **kwargs):
+            return QFileDialog.getSaveFileName_(*args, **kwargs), None
+
+    QStyleOptionViewItem = QStyleOptionViewItemV4

--- a/qutepart/rectangularselection.py
+++ b/qutepart/rectangularselection.py
@@ -1,5 +1,6 @@
-from PyQt4.QtCore import Qt, QMimeData
-from PyQt4.QtGui import QApplication, QKeyEvent, QKeySequence, QPalette, QTextCursor, QTextEdit, QWidget
+from qutepart.qt import Qt, QMimeData
+from qutepart.qt import QApplication, QTextEdit, QWidget
+from qutepart.qt import QKeyEvent, QKeySequence, QPalette, QTextCursor
 
 
 class RectangularSelection:

--- a/qutepart/sideareas.py
+++ b/qutepart/sideareas.py
@@ -1,10 +1,11 @@
 """Line numbers and bookmarks areas
 """
 
-from PyQt4.QtCore import QPoint, Qt, pyqtSignal
-from PyQt4.QtGui import QPainter, QPalette, \
+from qutepart.qt import QPoint, Qt, pyqtSignal
+from qutepart.qt import QWidget
+from qutepart.qt import QPainter, QPalette, \
                         QPixmap, \
-                        QTextBlock, QToolTip, QWidget
+                        QTextBlock, QToolTip
 
 import qutepart
 from qutepart.bookmarks import Bookmarks

--- a/qutepart/syntaxhlighter.py
+++ b/qutepart/syntaxhlighter.py
@@ -5,8 +5,9 @@ Uses syntax module for doing the job
 import time
 
 
-from PyQt4.QtCore import QObject, QTimer
-from PyQt4.QtGui import QApplication, QBrush, QColor, QFont, \
+from qutepart.qt import QObject, QTimer
+from qutepart.qt import QApplication
+from qutepart.qt import QBrush, QColor, QFont, \
                         QTextBlockUserData, QTextCharFormat, QTextLayout
 
 import qutepart.syntax

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,13 +3,9 @@ import sys
 import unittest
 import time
 
-
-import sip
-sip.setapi('QString', 2)
-
-from PyQt4.QtCore import Qt, QTimer
-from PyQt4.QtGui import QApplication
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt, QTimer
+from qutepart.qt import QApplication
+from qutepart.qt import QTest
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -6,8 +6,8 @@ import unittest
 
 import base
 
-from PyQt4.QtTest import QTest
-from PyQt4.QtCore import Qt, QTimer
+from qutepart.qt import QTest
+from qutepart.qt import Qt, QTimer
 
 from qutepart import Qutepart
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,8 +6,8 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt
+from qutepart.qt import QTest
 
 from qutepart import Qutepart
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -6,8 +6,8 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt, QTimer, QPoint
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt, QTimer, QPoint
+from qutepart.qt import QTest
 
 
 from qutepart import Qutepart, iterateBlocksFrom

--- a/tests/test_bracket_hlighter.py
+++ b/tests/test_bracket_hlighter.py
@@ -6,8 +6,8 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt
+from qutepart.qt import QTest
 
 from qutepart import Qutepart
 from qutepart.brackethlighter import BracketHighlighter

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -6,9 +6,9 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt, QPoint
-from PyQt4.QtGui import QMainWindow
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt, QPoint
+from qutepart.qt import QMainWindow
+from qutepart.qt import QTest
 
 from qutepart import Qutepart
 import qutepart.completer

--- a/tests/test_draw_whitespace.py
+++ b/tests/test_draw_whitespace.py
@@ -8,8 +8,8 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt
+from qutepart.qt import QTest
 
 from qutepart import Qutepart
 

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -5,8 +5,8 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt
+from qutepart.qt import QTest
 
 from qutepart import Qutepart
 

--- a/tests/test_indent.py
+++ b/tests/test_indent.py
@@ -5,8 +5,8 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt
+from qutepart.qt import QTest
 
 from qutepart import Qutepart
 

--- a/tests/test_indenter/indenttest.py
+++ b/tests/test_indenter/indenttest.py
@@ -1,10 +1,7 @@
 import unittest
 
-import sip
-sip.setapi('QString', 2)
-
-from PyQt4.QtCore import Qt
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt
+from qutepart.qt import QTest
 
 import sys
 import os

--- a/tests/test_rectangular_selection.py
+++ b/tests/test_rectangular_selection.py
@@ -8,8 +8,8 @@ import unittest
 
 import base
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtTest import QTest
+from qutepart.qt import Qt
+from qutepart.qt import QTest
 
 from qutepart import Qutepart
 


### PR DESCRIPTION
Cross-version support is added via `qt.py`, a shim that
handles the imports and incompatibilities between APIs.
Classes can then be imported from this directly to hide
these differences from the code.

This changes import style from:

    from PyQt4.QtGui import QAbstractTextDocumentLayout

to:

    from qutepart.qt import QAbstractTextDocumentLayout

All Qt classes are available in the root of the shim namespace.
Tests and core code has been updated to use this new style, and
tests pass with the following exceptions:

PyQt5 fails test_rectangular_selection.Test with 'Rectangular selection area is too big'
PyQt4 crashes on test_down_selects_first

A manual test using the QutePart in a PyQt4 and PyQt5 application
functions as expected.