### PR TITLE
Add preliminary Rust support

### DIFF
--- a/qutepart/syntax/data/syntax_db.json
+++ b/qutepart/syntax/data/syntax_db.json
@@ -330,6 +330,7 @@
         "*.rnc": "relaxngcompact.xml", 
         "*.rng": "relaxng.xml", 
         "*.rqb": "rapidq.xml", 
+        "*.rs": "rust.xml", 
         "*.rss": "xml.xml", 
         "*.rst": "restructuredtext.xml", 
         "*.rxml": "ruby.xml", 

--- a/qutepart/syntax/data/xml/rust.xml
+++ b/qutepart/syntax/data/xml/rust.xml
@@ -3,7 +3,7 @@
 <!--
   This file is part of KDE's kate project.
   
-  copyright   : (C) 2004 by Dominik Haumann, (C) 2011 by Caspar Hasenclever
+  copyright   : (C) 2004 by Dominik Haumann, (C) 2011 by Caspar Hasenclever, 2015 by Vitaly "_Vi" Shukela
 
  **********************************************************************
  * This library is free software; you can redistribute it and/or      *
@@ -22,7 +22,7 @@
  * Boston, MA  02110-1301, USA.                                       *
  **********************************************************************
  -->
-<language version="2" kateversion="2.3" name="Clojure" section="Sources" extensions="*.rs" mimetype="" author="Dominik Haumann [lisp] modified for clojure by Caspar Hasenclever; Modified for Rust by Vitaly '_Vi' Shukela" license="LGPL">
+<language version="1" kateversion="2.3" name="Rust" section="Sources" extensions="*.rs" mimetype="" author="Dominik Haumann [lisp] modified for clojure by Caspar Hasenclever; Modified for Rust by Vitaly '_Vi' Shukela" license="LGPL">
   <highlighting>
     <list name="definitions">
       <item> fn </item>

--- a/qutepart/syntax/data/xml/rust.xml
+++ b/qutepart/syntax/data/xml/rust.xml
@@ -1,204 +1,334 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE language SYSTEM "language.dtd">
-<!--
-  This file is part of KDE's kate project.
-  
-  copyright   : (C) 2004 by Dominik Haumann, (C) 2011 by Caspar Hasenclever, 2015 by Vitaly "_Vi" Shukela
-
- **********************************************************************
- * This library is free software; you can redistribute it and/or      *
- * modify it under the terms of the GNU Library General Public        *
- * License as published by the Free Software Foundation; either       *
- * version 2 of the License, or (at your option) any later version.   *
- *                                                                    *
- * This library is distributed in the hope that it will be useful,    *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of     *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  *
- * Library General Public License for more details.                   *
- *                                                                    *
- * You should have received a copy of the GNU Library General Public  *
- * License along with this library; if not, write to the              *
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,       *
- * Boston, MA  02110-1301, USA.                                       *
- **********************************************************************
- -->
-<language version="1" kateversion="2.3" name="Rust" section="Sources" extensions="*.rs" mimetype="" author="Dominik Haumann [lisp] modified for clojure by Caspar Hasenclever; Modified for Rust by Vitaly '_Vi' Shukela" license="LGPL">
-  <highlighting>
-    <list name="definitions">
-      <item> fn </item>
-      <item> struct </item>
-      <item> enum </item>
-      <item> macro_rules! </item>
-      <item> trait </item>
-    </list>
-    <list name="keywords">
-      <item> &lt; </item>
-      <item> &lt;= </item>
-      <item> = </item>
-      <item> == </item>
-      <item> &gt; </item>
-      <item> &gt;= </item>
-      <item> - </item>
-      <item> -&gt; </item>
-      <item> -&gt;&gt; </item>
-      <item> / </item>
-      <item> . </item>
-      <item> * </item>
-      <item> + </item>
-      <item> panic! </item>
-      <item> assert_eq! </item>
-      <item> abstract </item> 
-      <item> alignof </item> 
-      <item> as </item> 
-      <item> be </item> 
-      <item> box </item> 
-      <item> break </item> 
-      <item> const </item> 
-      <item> continue </item> 
-      <item> crate </item> 
-      <item> do </item> 
-      <item> else </item> 
-      <item> extern </item> 
-      <item> false </item> 
-      <item> final </item> 
-      <item> for </item> 
-      <item> if </item> 
-      <item> impl </item> 
-      <item> in </item> 
-      <item> let </item> 
-      <item> loop </item> 
-      <item> macro </item> 
-      <item> match </item> 
-      <item> mod </item> 
-      <item> move </item> 
-      <item> mut </item> 
-      <item> offsetof </item> 
-      <item> override </item> 
-      <item> priv </item> 
-      <item> pub </item> 
-      <item> pure </item> 
-      <item> ref </item> 
-      <item> return </item> 
-      <item> sizeof </item> 
-      <item> static </item> 
-      <item> self </item> 
-      <item> super </item> 
-      <item> true </item> 
-      <item> type </item> 
-      <item> typeof </item> 
-      <item> unsafe </item> 
-      <item> unsized </item> 
-      <item> use </item> 
-      <item> virtual </item> 
-      <item> where </item> 
-      <item> while </item> 
-      <item> yield </item> 
-    </list>
-    <list name="variables">
-    </list>
-    <contexts>
-      <context name="Level0" attribute="Normal" lineEndContext="#stay">
-        <DetectChar attribute="Brackets1" context="Level1" char="("/>
-        <Detect2Chars attribute="Brackets1" context="Level1" char="#" char1="("/>
-        <IncludeRules context="Default" />
-      </context>
-      <context name="Default" attribute="Normal" lineEndContext="#stay">
-        <RegExpr attribute="Comment" context="#stay" String="/\*.*\*/"/>
-        <RegExpr attribute="Comment" context="#stay" String="//.*$"/>
-        <DetectChar attribute="BracketsCurly" context="#stay" char="{"/>
-        <DetectChar attribute="BracketsCurly" context="#stay" char="}"/>
-        <DetectChar attribute="BracketsSquare" context="#stay" char="["/>
-        <DetectChar attribute="BracketsSquare" context="#stay" char="]"/>
-        <keyword attribute="Keyword" context="#stay" String="keywords"/>
-        <!-- <keyword attribute="Variable" context="#stay" String="variables"/> -->
-        <keyword attribute="Definition" context="#stay" String="definitions"/>
-        <RegExpr attribute="Char" context="#stay" String="\\."/>
-        <Detect2Chars attribute="String" context="String" char="#" char1="&quot;"/>
-        <DetectChar attribute="String" context="String" char="&quot;"/>
-        <Float attribute="Float" context="#stay"/>
-        <Int attribute="Decimal" context="#stay"/>
-        <DetectChar attribute="Brackets1" context="Level1" char="("/>
-      </context>
-      <context name="SpecialNumber" attribute="Normal" lineEndContext="#pop">
-        <Float attribute="Float" context="#pop"/>
-        <Int attribute="Decimal" context="#pop"/>
-        <HlCOct attribute="BaseN" context="#pop"/>
-        <HlCHex attribute="Float" context="#pop"/>
-      </context>
-      <context name="String" attribute="String" lineEndContext="#stay">
-        <RegExpr attribute="Char" context="#stay" String="#\\."/>
-        <HlCStringChar attribute="String Char" context="#stay"/>
-        <DetectChar attribute="String" context="#pop" char="&quot;"/>
-      </context>
-      <context name="Level1" attribute="Normal" lineEndContext="#stay">
-        <DetectChar attribute="Brackets2" context="Level2" char="("/>
-        <Detect2Chars attribute="Brackets2" context="Level2" char="#" char1="("/>
-        <DetectChar attribute="Brackets1" context="#pop" char=")" />
-        <IncludeRules context="Default" />
-      </context>
-      <context name="Level2" attribute="Normal" lineEndContext="#stay">
-        <DetectChar attribute="Brackets3" context="Level3" char="("/>
-        <Detect2Chars attribute="Brackets3" context="Level3" char="#" char1="("/>
-        <DetectChar attribute="Brackets2" context="#pop" char=")" />
-        <IncludeRules context="Default" />
-      </context>
-      <context name="Level3" attribute="Normal" lineEndContext="#stay">
-        <DetectChar attribute="Brackets4" context="Level4" char="("/>
-        <Detect2Chars attribute="Brackets4" context="Level4" char="#" char1="("/>
-        <DetectChar attribute="Brackets3" context="#pop" char=")" />
-        <IncludeRules context="Default" />
-      </context>
-      <context name="Level4" attribute="Normal" lineEndContext="#stay">
-        <DetectChar attribute="Brackets5" context="Level5" char="("/>
-        <Detect2Chars attribute="Brackets5" context="Level5" char="#" char1="("/>
-        <DetectChar attribute="Brackets4" context="#pop" char=")" />
-        <IncludeRules context="Default" />
-      </context>
-      <context name="Level5" attribute="Normal" lineEndContext="#stay">
-        <DetectChar attribute="Brackets6" context="Level6" char="("/>
-        <Detect2Chars attribute="Brackets6" context="Level6" char="#" char1="("/>
-        <DetectChar attribute="Brackets5" context="#pop" char=")" />
-        <IncludeRules context="Default" />
-      </context>
-      <context name="Level6" attribute="Normal" lineEndContext="#stay">
-        <DetectChar attribute="Brackets1" context="Level1" char="("/>
-        <Detect2Chars attribute="Brackets1" context="Level1" char="#" char1="("/>
-        <DetectChar attribute="Brackets6" context="#pop" char=")" />
-        <IncludeRules context="Default" />
-      </context>
-    </contexts>
-    <itemDatas>
-      <itemData name="Normal" defStyleNum="dsNormal"/>
-      <itemData name="Keyword" defStyleNum="dsKeyword"/>
-      <itemData name="Operator" defStyleNum="dsKeyword" color="#d22811"/>
-      <itemData name="Modifier" defStyleNum="dsKeyword" color="#800000"/>
-      <itemData name="Modifier2" defStyleNum="dsKeyword" color="#555555"/>
-      <itemData name="Variable" defStyleNum="dsKeyword" color="#b07e1f"/>
-      <itemData name="Definition" defStyleNum="dsKeyword" color="#d22811"/>
-      <itemData name="Data" defStyleNum="dsDataType"/>
-      <itemData name="Decimal" defStyleNum="dsDecVal"/>
-      <itemData name="BaseN" defStyleNum="dsBaseN"/>
-      <itemData name="Float" defStyleNum="dsFloat"/>
-      <itemData name="Function" defStyleNum="dsFunction"/>
-      <itemData name="Char" defStyleNum="dsChar"/>
-      <itemData name="String" defStyleNum="dsString"/>
-      <itemData name="Comment" defStyleNum="dsComment"/>
-      <itemData name="Region Marker" defStyleNum="dsRegionMarker"/>
-      <itemData name="Brackets" defStyleNum="dsNormal" color="#0000ff" selColor="#00ff00" bold="1" italic="0"/>
-      <itemData name="BracketsSquare" defStyleNum="dsNormal" color="#3333ff" selColor="#3333aa"/>
-      <itemData name="BracketsCurly" defStyleNum="dsNormal" color="#206620" selColor="#219921"/>
-      <itemData name="Brackets1"    defStyleNum="dsNormal" color="#ff0000" selColor="#ffaa00" bold="0" italic="0"/>
-      <itemData name="Brackets2"    defStyleNum="dsNormal" color="#ff8800" selColor="#ffff00" bold="0" italic="0"/>
-      <itemData name="Brackets3"    defStyleNum="dsNormal" color="#888800" selColor="#888888" bold="0" italic="0"/>
-      <itemData name="Brackets4"    defStyleNum="dsNormal" color="#008800" selColor="#000000" bold="0" italic="0"/>
-      <itemData name="Brackets5"    defStyleNum="dsNormal" color="#000088" selColor="#000000" bold="0" italic="0"/>
-      <itemData name="Brackets6"    defStyleNum="dsNormal" color="#880088" selColor="#000000" bold="0" italic="0"/>
-    </itemDatas>
-  </highlighting>
-  <general>
-    <keywords casesensitive="1" weakDeliminator=""/>
-    <comments>
-      <comment name="singleLine" start="//"/>
-    </comments>
-  </general>
+<!DOCTYPE language SYSTEM "language.dtd"
+[
+	<!-- FIXME: Kate's regex engine has very limited support for
+	predefined char classes, so making rustIdent consistent with actual
+	Rust identifiers will be a bit difficult -->
+	<!ENTITY rustIdent "[a-zA-Z_][a-zA-Z_0-9]*">
+	<!ENTITY rustIntSuf "([iu](8|16|32|64)?)?">
+]>
+<language name="Rust" version="1.0.0" kateversion="2.4" section="Sources" extensions="*.rs" mimetype="text/x-rust" priority="15">
+<highlighting>
+	<list name="fn">
+		<item> fn </item>
+	</list>
+	<list name="type">
+		<item> type </item>
+	</list>
+	<list name="reserved">
+		<item> abstract </item>
+		<item> alignof </item>
+		<item> be </item>
+		<item> do </item>
+		<item> final </item>
+		<item> offsetof </item>
+		<item> override </item>
+		<item> priv </item>
+		<item> pure </item>
+		<item> sizeof </item>
+		<item> typeof </item>
+		<item> unsized </item>
+		<item> yield </item>
+	</list>
+	<list name="keywords">
+		<item> as </item>
+		<item> box </item>
+		<item> break </item>
+		<item> const </item>
+		<item> continue </item>
+		<item> crate </item>
+		<item> else </item>
+		<item> enum </item>
+		<item> extern </item>
+		<item> for </item>
+		<item> if </item>
+		<item> impl </item>
+		<item> in </item>
+		<item> let </item>
+		<item> loop </item>
+		<item> match </item>
+		<item> mod </item>
+		<item> move </item>
+		<item> mut </item>
+		<item> pub </item>
+		<item> ref </item>
+		<item> return </item>
+		<item> static </item>
+		<item> struct </item>
+		<item> super </item>
+		<item> trait </item>
+		<item> unsafe </item>
+		<item> use </item>
+		<item> virtual </item>
+		<item> where </item>
+		<item> while </item>
+	</list>
+	<list name="traits">
+		<item> AsSlice </item>
+		<item> CharExt </item>
+		<item> Clone </item>
+		<item> Copy </item>
+		<item> Debug </item>
+		<item> Decodable </item>
+		<item> Default </item>
+		<item> Display </item>
+		<item> DoubleEndedIterator </item>
+		<item> Drop </item>
+		<item> Encodable </item>
+		<item> Eq </item>
+		<item> Default </item>
+		<item> Extend </item>
+		<item> Fn </item>
+		<item> FnMut </item>
+		<item> FnOnce </item>
+		<item> FromPrimitive </item>
+		<item> Hash </item>
+		<item> Iterator </item>
+		<item> IteratorExt </item>
+		<item> MutPtrExt </item>
+		<item> Ord </item>
+		<item> PartialEq </item>
+		<item> PartialOrd </item>
+		<item> PtrExt </item>
+		<item> Rand </item>
+		<item> Send </item>
+		<item> Sized </item>
+		<item> SliceConcatExt </item>
+		<item> SliceExt </item>
+		<item> Str </item>
+		<item> StrExt </item>
+		<item> Sync </item>
+		<item> ToString </item>
+	</list>
+	<list name="types">
+		<item> bool </item>
+		<item> int </item>
+		<item> isize </item>
+		<item> uint </item>
+		<item> usize </item>
+		<item> i8 </item>
+		<item> i16 </item>
+		<item> i32 </item>
+		<item> i64 </item>
+		<item> u8 </item>
+		<item> u16 </item>
+		<item> u32 </item>
+		<item> u64 </item>
+		<item> f32 </item>
+		<item> f64 </item>
+		<item> float </item>
+		<item> char </item>
+		<item> str </item>
+		<item> Option </item>
+		<item> Result </item>
+		<item> Self </item>
+		<item> Box </item>
+		<item> Vec </item>
+		<item> String </item>
+	</list>
+	<list name="ctypes">
+		<item> c_float </item>
+		<item> c_double </item>
+		<item> c_void </item>
+		<item> FILE </item>
+		<item> fpos_t </item>
+		<item> DIR </item>
+		<item> dirent </item>
+		<item> c_char </item>
+		<item> c_schar </item>
+		<item> c_uchar </item>
+		<item> c_short </item>
+		<item> c_ushort </item>
+		<item> c_int </item>
+		<item> c_uint </item>
+		<item> c_long </item>
+		<item> c_ulong </item>
+		<item> size_t </item>
+		<item> ptrdiff_t </item>
+		<item> clock_t </item>
+		<item> time_t </item>
+		<item> c_longlong </item>
+		<item> c_ulonglong </item>
+		<item> intptr_t </item>
+		<item> uintptr_t </item>
+		<item> off_t </item>
+		<item> dev_t </item>
+		<item> ino_t </item>
+		<item> pid_t </item>
+		<item> mode_t </item>
+		<item> ssize_t </item>
+	</list>
+	<list name="self">
+		<item> self </item>
+	</list>
+	<list name="constants">
+		<item> true </item>
+		<item> false </item>
+		<item> Some </item>
+		<item> None </item>
+		<item> Ok </item>
+		<item> Err </item>
+		<item> Success </item>
+		<item> Failure </item>
+		<item> Cons </item>
+		<item> Nil </item>
+	</list>
+	<list name="cconstants">
+		<item> EXIT_FAILURE </item>
+		<item> EXIT_SUCCESS </item>
+		<item> RAND_MAX </item>
+		<item> EOF </item>
+		<item> SEEK_SET </item>
+		<item> SEEK_CUR </item>
+		<item> SEEK_END </item>
+		<item> _IOFBF </item>
+		<item> _IONBF </item>
+		<item> _IOLBF </item>
+		<item> BUFSIZ </item>
+		<item> FOPEN_MAX </item>
+		<item> FILENAME_MAX </item>
+		<item> L_tmpnam </item>
+		<item> TMP_MAX </item>
+		<item> O_RDONLY </item>
+		<item> O_WRONLY </item>
+		<item> O_RDWR </item>
+		<item> O_APPEND </item>
+		<item> O_CREAT </item>
+		<item> O_EXCL </item>
+		<item> O_TRUNC </item>
+		<item> S_IFIFO </item>
+		<item> S_IFCHR </item>
+		<item> S_IFBLK </item>
+		<item> S_IFDIR </item>
+		<item> S_IFREG </item>
+		<item> S_IFMT </item>
+		<item> S_IEXEC </item>
+		<item> S_IWRITE </item>
+		<item> S_IREAD </item>
+		<item> S_IRWXU </item>
+		<item> S_IXUSR </item>
+		<item> S_IWUSR </item>
+		<item> S_IRUSR </item>
+		<item> F_OK </item>
+		<item> R_OK </item>
+		<item> W_OK </item>
+		<item> X_OK </item>
+		<item> STDIN_FILENO </item>
+		<item> STDOUT_FILENO </item>
+		<item> STDERR_FILENO </item>
+	</list>
+	<contexts>
+		<context attribute="Normal Text" lineEndContext="#stay" name="Normal">
+			<DetectSpaces/>
+			<keyword String="fn" attribute="Keyword" context="Function"/>
+			<keyword String="type" attribute="Keyword" context="Type"/>
+			<keyword String="reserved" attribute="Keyword" context="#stay"/>
+			<keyword String="keywords" attribute="Keyword" context="#stay"/>
+			<keyword String="types" attribute="Type" context="#stay"/>
+			<keyword String="traits" attribute="Trait" context="#stay"/>
+			<keyword String="ctypes" attribute="CType" context="#stay"/>
+			<keyword String="self" attribute="Self" context="#stay"/>
+			<keyword String="constants" attribute="Constant" context="#stay"/>
+			<keyword String="cconstants" attribute="CConstant" context="#stay"/>
+			<Detect2Chars char="/" char1="/" attribute="Comment" context="Commentar 1"/>
+			<Detect2Chars char="/" char1="*" attribute="Comment" context="Commentar 2" beginRegion="Comment"/>
+			<RegExpr String="0x[0-9a-fA-F_]+&rustIntSuf;" attribute="Number" context="#stay"/>
+			<RegExpr String="0o[0-7_]+&rustIntSuf;" attribute="Number" context="#stay"/>
+			<RegExpr String="0b[0-1_]+&rustIntSuf;" attribute="Number" context="#stay"/>
+			<RegExpr String="[0-9][0-9_]*\.[0-9_]*([eE][+-]?[0-9_]+)?(f32|f64|f)?" attribute="Number" context="#stay"/>
+			<RegExpr String="[0-9][0-9_]*&rustIntSuf;" attribute="Number" context="#stay"/>
+			<Detect2Chars char="#" char1="[" attribute="Attribute" context="Attribute" beginRegion="Attribute"/>
+			<StringDetect String="#![" attribute="Attribute" context="Attribute" beginRegion="Attribute"/>
+			<RegExpr String="&rustIdent;::" attribute="Scope"/>
+			<RegExpr String="&rustIdent;!" attribute="Macro"/>
+			<RegExpr String="&apos;&rustIdent;(?!&apos;)" attribute="Lifetime"/>
+			<DetectChar char="{" attribute="Symbol" context="#stay" beginRegion="Brace" />
+			<DetectChar char="}" attribute="Symbol" context="#stay" endRegion="Brace" />
+                        <Detect2Chars char="r" char1="&quot;" attribute="String" context="RawString"/>
+                        <StringDetect String="r##&quot;" attribute="String" context="RawHashed2"/>
+                        <StringDetect String="r#&quot;" attribute="String" context="RawHashed1"/>
+			<DetectChar char="&quot;" attribute="String" context="String"/>
+			<DetectChar char="&apos;" attribute="Character" context="Character"/>
+			<DetectChar char="[" attribute="Symbol" context="#stay" beginRegion="Bracket" />
+			<DetectChar char="]" attribute="Symbol" context="#stay" endRegion="Bracket" />
+			<DetectIdentifier/>
+		</context>
+		<context attribute="Attribute" lineEndContext="#stay" name="Attribute">
+			<DetectChar char="]" attribute="Attribute" context="#pop" endRegion="Attribute"/>
+			<IncludeRules context="Normal"/>
+		</context>
+		<context attribute="Definition" lineEndContext="#stay" name="Function">
+			<DetectSpaces/>
+			<DetectChar char="(" attribute="Normal Text" context="#pop"/>
+			<DetectChar char="&lt;" attribute="Normal Text" context="#pop"/>
+		</context>
+		<context attribute="Definition" lineEndContext="#stay" name="Type">
+			<DetectSpaces/>
+			<DetectChar char="=" attribute="Normal Text" context="#pop"/>
+			<DetectChar char="&lt;" attribute="Normal Text" context="#pop"/>
+		</context>
+                <!-- Rustc allows strings to extend over multiple lines, and the
+                only thing a backshash at end-of-line does is remove the whitespace. -->
+                <context attribute="String" lineEndContext="#stay" name="String">
+                        <DetectChar char="\" attribute="CharEscape" context="CharEscape"/>
+                        <DetectChar attribute="String" context="#pop" char="&quot;"/>
+                </context>
+		<context attribute="String" lineEndContext="#stay" name="RawString">
+			<DetectChar attribute="String" context="#pop" char="&quot;"/>
+		</context>
+                <!-- These rules are't complete: they won't match r###"abc"### -->
+                <context attribute="String" lineEndContext="#stay" name="RawHashed1">
+                        <Detect2Chars attribute="String" context="#pop" char="&quot;" char1="#"/>
+                </context>
+                <context attribute="String" lineEndContext="#stay" name="RawHashed2">
+                        <StringDetect attribute="String" context="#pop" String="&quot;##"/>
+                </context>
+		<context attribute="Character" lineEndContext="#pop" name="Character">
+			<DetectChar char="\" attribute="CharEscape" context="CharEscape"/>
+			<DetectChar attribute="Character" context="#pop" char="&apos;"/>
+		</context>
+		<context attribute="CharEscape" lineEndContext="#pop" name="CharEscape">
+			<AnyChar String="nrt\&apos;&quot;" attribute="CharEscape" context="#pop"/>
+			<RegExpr String="x[0-9a-fA-F]{2}" attribute="CharEscape" context="#pop"/>
+			<RegExpr String="u\{[0-9a-fA-F]{1,6}\}" attribute="CharEscape" context="#pop"/>
+			<RegExpr String="u[0-9a-fA-F]{4}" attribute="CharEscape" context="#pop"/>
+			<RegExpr String="U[0-9a-fA-F]{8}" attribute="CharEscape" context="#pop"/>
+			<RegExpr String="." attribute="Error" context="#pop"/>
+		</context>
+		<context attribute="Comment" lineEndContext="#pop" name="Commentar 1"/>
+		<context attribute="Comment" lineEndContext="#stay" name="Commentar 2">
+			<DetectSpaces/>
+			<Detect2Chars char="*" char1="/" attribute="Comment" context="#pop" endRegion="Comment"/>
+		</context>
+	</contexts>
+	<itemDatas>
+		<itemData name="Normal Text"  defStyleNum="dsNormal"/>
+		<itemData name="Keyword"      defStyleNum="dsKeyword" color="#770088" bold="1"/>
+		<itemData name="Self"         defStyleNum="dsKeyword" color="#FF0000" bold="1"/>
+		<itemData name="Type"         defStyleNum="dsKeyword" color="#4e9a06" bold="1"/>
+		<itemData name="Trait"        defStyleNum="dsKeyword" color="#4e9a06" bold="1"/>
+		<itemData name="CType"        defStyleNum="dsNormal" color="#4e9a06"/>
+		<itemData name="Constant"     defStyleNum="dsKeyword" color="#116644"/>
+		<itemData name="CConstant"    defStyleNum="dsNormal" color="#116644"/>
+		<itemData name="Definition"   defStyleNum="dsNormal" color="#0000FF"/>
+		<itemData name="Comment"      defStyleNum="dsComment" color="#AA5500"/>
+		<itemData name="Scope"        defStyleNum="dsNormal" color="#0055AA"/>
+		<itemData name="Number"       defStyleNum="dsDecVal" color="#116644"/>
+		<itemData name="String"       defStyleNum="dsString" color="#FF0000"/>
+		<itemData name="CharEscape"   defStyleNum="dsChar" color="#FF0000" bold="1"/>
+		<itemData name="Character"    defStyleNum="dsChar" color="#FF0000"/>
+		<itemData name="Macro"        defStyleNum="dsOthers"/>
+		<itemData name="Attribute"    defStyleNum="dsOthers"/>
+		<itemData name="Lifetime"     defStyleNum="dsOthers" bold="1"/>
+		<itemData name="Error"        defStyleNum="dsError"/>
+	</itemDatas>
+</highlighting>
+<general>
+	<comments>
+		<comment name="singleLine" start="//" />
+		<comment name="multiLine" start="/*" end="*/" region="Comment"/>
+	</comments>
+	<keywords casesensitive="1" />
+</general>
 </language>
+

--- a/qutepart/syntax/data/xml/rust.xml
+++ b/qutepart/syntax/data/xml/rust.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language SYSTEM "language.dtd">
+<!--
+  This file is part of KDE's kate project.
+  
+  copyright   : (C) 2004 by Dominik Haumann, (C) 2011 by Caspar Hasenclever
+
+ **********************************************************************
+ * This library is free software; you can redistribute it and/or      *
+ * modify it under the terms of the GNU Library General Public        *
+ * License as published by the Free Software Foundation; either       *
+ * version 2 of the License, or (at your option) any later version.   *
+ *                                                                    *
+ * This library is distributed in the hope that it will be useful,    *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  *
+ * Library General Public License for more details.                   *
+ *                                                                    *
+ * You should have received a copy of the GNU Library General Public  *
+ * License along with this library; if not, write to the              *
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,       *
+ * Boston, MA  02110-1301, USA.                                       *
+ **********************************************************************
+ -->
+<language version="2" kateversion="2.3" name="Clojure" section="Sources" extensions="*.rs" mimetype="" author="Dominik Haumann [lisp] modified for clojure by Caspar Hasenclever; Modified for Rust by Vitaly '_Vi' Shukela" license="LGPL">
+  <highlighting>
+    <list name="definitions">
+      <item> fn </item>
+      <item> struct </item>
+      <item> enum </item>
+      <item> macro_rules! </item>
+      <item> trait </item>
+    </list>
+    <list name="keywords">
+      <item> &lt; </item>
+      <item> &lt;= </item>
+      <item> = </item>
+      <item> == </item>
+      <item> &gt; </item>
+      <item> &gt;= </item>
+      <item> - </item>
+      <item> -&gt; </item>
+      <item> -&gt;&gt; </item>
+      <item> / </item>
+      <item> . </item>
+      <item> * </item>
+      <item> + </item>
+      <item> panic! </item>
+      <item> assert_eq! </item>
+      <item> abstract </item> 
+      <item> alignof </item> 
+      <item> as </item> 
+      <item> be </item> 
+      <item> box </item> 
+      <item> break </item> 
+      <item> const </item> 
+      <item> continue </item> 
+      <item> crate </item> 
+      <item> do </item> 
+      <item> else </item> 
+      <item> extern </item> 
+      <item> false </item> 
+      <item> final </item> 
+      <item> for </item> 
+      <item> if </item> 
+      <item> impl </item> 
+      <item> in </item> 
+      <item> let </item> 
+      <item> loop </item> 
+      <item> macro </item> 
+      <item> match </item> 
+      <item> mod </item> 
+      <item> move </item> 
+      <item> mut </item> 
+      <item> offsetof </item> 
+      <item> override </item> 
+      <item> priv </item> 
+      <item> pub </item> 
+      <item> pure </item> 
+      <item> ref </item> 
+      <item> return </item> 
+      <item> sizeof </item> 
+      <item> static </item> 
+      <item> self </item> 
+      <item> super </item> 
+      <item> true </item> 
+      <item> type </item> 
+      <item> typeof </item> 
+      <item> unsafe </item> 
+      <item> unsized </item> 
+      <item> use </item> 
+      <item> virtual </item> 
+      <item> where </item> 
+      <item> while </item> 
+      <item> yield </item> 
+    </list>
+    <list name="variables">
+    </list>
+    <contexts>
+      <context name="Level0" attribute="Normal" lineEndContext="#stay">
+        <DetectChar attribute="Brackets1" context="Level1" char="("/>
+        <Detect2Chars attribute="Brackets1" context="Level1" char="#" char1="("/>
+        <IncludeRules context="Default" />
+      </context>
+      <context name="Default" attribute="Normal" lineEndContext="#stay">
+        <RegExpr attribute="Comment" context="#stay" String="/\*.*\*/"/>
+        <RegExpr attribute="Comment" context="#stay" String="//.*$"/>
+        <DetectChar attribute="BracketsCurly" context="#stay" char="{"/>
+        <DetectChar attribute="BracketsCurly" context="#stay" char="}"/>
+        <DetectChar attribute="BracketsSquare" context="#stay" char="["/>
+        <DetectChar attribute="BracketsSquare" context="#stay" char="]"/>
+        <keyword attribute="Keyword" context="#stay" String="keywords"/>
+        <!-- <keyword attribute="Variable" context="#stay" String="variables"/> -->
+        <keyword attribute="Definition" context="#stay" String="definitions"/>
+        <RegExpr attribute="Char" context="#stay" String="\\."/>
+        <Detect2Chars attribute="String" context="String" char="#" char1="&quot;"/>
+        <DetectChar attribute="String" context="String" char="&quot;"/>
+        <Float attribute="Float" context="#stay"/>
+        <Int attribute="Decimal" context="#stay"/>
+        <DetectChar attribute="Brackets1" context="Level1" char="("/>
+      </context>
+      <context name="SpecialNumber" attribute="Normal" lineEndContext="#pop">
+        <Float attribute="Float" context="#pop"/>
+        <Int attribute="Decimal" context="#pop"/>
+        <HlCOct attribute="BaseN" context="#pop"/>
+        <HlCHex attribute="Float" context="#pop"/>
+      </context>
+      <context name="String" attribute="String" lineEndContext="#stay">
+        <RegExpr attribute="Char" context="#stay" String="#\\."/>
+        <HlCStringChar attribute="String Char" context="#stay"/>
+        <DetectChar attribute="String" context="#pop" char="&quot;"/>
+      </context>
+      <context name="Level1" attribute="Normal" lineEndContext="#stay">
+        <DetectChar attribute="Brackets2" context="Level2" char="("/>
+        <Detect2Chars attribute="Brackets2" context="Level2" char="#" char1="("/>
+        <DetectChar attribute="Brackets1" context="#pop" char=")" />
+        <IncludeRules context="Default" />
+      </context>
+      <context name="Level2" attribute="Normal" lineEndContext="#stay">
+        <DetectChar attribute="Brackets3" context="Level3" char="("/>
+        <Detect2Chars attribute="Brackets3" context="Level3" char="#" char1="("/>
+        <DetectChar attribute="Brackets2" context="#pop" char=")" />
+        <IncludeRules context="Default" />
+      </context>
+      <context name="Level3" attribute="Normal" lineEndContext="#stay">
+        <DetectChar attribute="Brackets4" context="Level4" char="("/>
+        <Detect2Chars attribute="Brackets4" context="Level4" char="#" char1="("/>
+        <DetectChar attribute="Brackets3" context="#pop" char=")" />
+        <IncludeRules context="Default" />
+      </context>
+      <context name="Level4" attribute="Normal" lineEndContext="#stay">
+        <DetectChar attribute="Brackets5" context="Level5" char="("/>
+        <Detect2Chars attribute="Brackets5" context="Level5" char="#" char1="("/>
+        <DetectChar attribute="Brackets4" context="#pop" char=")" />
+        <IncludeRules context="Default" />
+      </context>
+      <context name="Level5" attribute="Normal" lineEndContext="#stay">
+        <DetectChar attribute="Brackets6" context="Level6" char="("/>
+        <Detect2Chars attribute="Brackets6" context="Level6" char="#" char1="("/>
+        <DetectChar attribute="Brackets5" context="#pop" char=")" />
+        <IncludeRules context="Default" />
+      </context>
+      <context name="Level6" attribute="Normal" lineEndContext="#stay">
+        <DetectChar attribute="Brackets1" context="Level1" char="("/>
+        <Detect2Chars attribute="Brackets1" context="Level1" char="#" char1="("/>
+        <DetectChar attribute="Brackets6" context="#pop" char=")" />
+        <IncludeRules context="Default" />
+      </context>
+    </contexts>
+    <itemDatas>
+      <itemData name="Normal" defStyleNum="dsNormal"/>
+      <itemData name="Keyword" defStyleNum="dsKeyword"/>
+      <itemData name="Operator" defStyleNum="dsKeyword" color="#d22811"/>
+      <itemData name="Modifier" defStyleNum="dsKeyword" color="#800000"/>
+      <itemData name="Modifier2" defStyleNum="dsKeyword" color="#555555"/>
+      <itemData name="Variable" defStyleNum="dsKeyword" color="#b07e1f"/>
+      <itemData name="Definition" defStyleNum="dsKeyword" color="#d22811"/>
+      <itemData name="Data" defStyleNum="dsDataType"/>
+      <itemData name="Decimal" defStyleNum="dsDecVal"/>
+      <itemData name="BaseN" defStyleNum="dsBaseN"/>
+      <itemData name="Float" defStyleNum="dsFloat"/>
+      <itemData name="Function" defStyleNum="dsFunction"/>
+      <itemData name="Char" defStyleNum="dsChar"/>
+      <itemData name="String" defStyleNum="dsString"/>
+      <itemData name="Comment" defStyleNum="dsComment"/>
+      <itemData name="Region Marker" defStyleNum="dsRegionMarker"/>
+      <itemData name="Brackets" defStyleNum="dsNormal" color="#0000ff" selColor="#00ff00" bold="1" italic="0"/>
+      <itemData name="BracketsSquare" defStyleNum="dsNormal" color="#3333ff" selColor="#3333aa"/>
+      <itemData name="BracketsCurly" defStyleNum="dsNormal" color="#206620" selColor="#219921"/>
+      <itemData name="Brackets1"    defStyleNum="dsNormal" color="#ff0000" selColor="#ffaa00" bold="0" italic="0"/>
+      <itemData name="Brackets2"    defStyleNum="dsNormal" color="#ff8800" selColor="#ffff00" bold="0" italic="0"/>
+      <itemData name="Brackets3"    defStyleNum="dsNormal" color="#888800" selColor="#888888" bold="0" italic="0"/>
+      <itemData name="Brackets4"    defStyleNum="dsNormal" color="#008800" selColor="#000000" bold="0" italic="0"/>
+      <itemData name="Brackets5"    defStyleNum="dsNormal" color="#000088" selColor="#000000" bold="0" italic="0"/>
+      <itemData name="Brackets6"    defStyleNum="dsNormal" color="#880088" selColor="#000000" bold="0" italic="0"/>
+    </itemDatas>
+  </highlighting>
+  <general>
+    <keywords casesensitive="1" weakDeliminator=""/>
+    <comments>
+      <comment name="singleLine" start="//"/>
+    </comments>
+  </general>
+</language>


### PR DESCRIPTION
It is my the first syntax highligh file at all, so I don't expect it to be clean.
It is based on Clojure's syntax file (because of I like rainbow parentheses feature) with tweaks for Rust.
Currently the code looks better compared to no syntax highlight.

TODO:
* Ranbow brackets for {} and <>
* Recognition of common standard library things
* Recognition of 0xHEX numbers