### PR TITLE
Add: Smart home feature.

### DIFF
--- a/qutepart/__init__.py
+++ b/qutepart/__init__.py
@@ -1233,16 +1233,46 @@ class Qutepart(QPlainTextEdit):
         self._onShortcutScroll(down)
 
     def _onShortcutHome(self, select):
-        """Home pressed, move cursor to the line start or to the text start
+        """Home pressed. Run a state machine:
+
+            1. Not at the line beginning. Move to the beginning of the line or
+               the beginning of the indent, whichever is closest to the current
+               cursor position.
+            2. At the line beginning. Move to the beginning of the indent.
+            3. At the beginning of the indent. Go to the beginning of the block.
+            4. At the beginning of the block. Go to the beginning of the indent.
         """
+        # Gather info for cursor state and movement.
         cursor = self.textCursor()
-        anchor = QTextCursor.KeepAnchor if select else QTextCursor.MoveAnchor
         text = cursor.block().text()
-        spaceAtStartLen = len(text) - len(text.lstrip())
-        if cursor.positionInBlock() == spaceAtStartLen:  # if at start of text
-            setPositionInBlock(cursor, 0, anchor)
+        indent = len(text) - len(text.lstrip())
+        anchor = QTextCursor.KeepAnchor if select else QTextCursor.MoveAnchor
+
+        # Determine current state and move based on that.
+        if cursor.positionInBlock() == indent:
+            # We're at the beginning of the indent. Go to the beginning of the
+            # block.
+            cursor.movePosition(QTextCursor.StartOfBlock, anchor)
+        elif cursor.atBlockStart():
+            # We're at the beginning of the block. Go to the beginning of the
+            # indent.
+            setPositionInBlock(cursor, indent, anchor)
         else:
-            setPositionInBlock(cursor, spaceAtStartLen, anchor)
+            # Neither of the above. There's no way I can find to directly
+            # determine if we're at the beginning of a line. So, try moving and
+            # see if the cursor location changes.
+            pos = cursor.positionInBlock()
+            cursor.movePosition(QTextCursor.StartOfLine, anchor)
+            # If we didn't move, we were already at the beginning of the line.
+            # So, move to the indent.
+            if pos == cursor.positionInBlock():
+                setPositionInBlock(cursor, indent, anchor)
+            # If we did move, check to see if the indent was closer to the
+            # cursor than the beginning of the indent. If so, move to the
+            # indent.
+            elif cursor.positionInBlock() < indent:
+                setPositionInBlock(cursor, indent, anchor)
+
         self.setTextCursor(cursor)
 
     def _selectLines(self, startBlockNumber, endBlockNumber):

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -67,6 +67,46 @@ class Test(unittest.TestCase):
         QTest.keyClick(self.qpart, Qt.Key_A)
         self.assertEqual(self.qpart.text, 'a')
 
+    def test_home1(self):
+        """ Test the operation of the home key. """
+
+        self.qpart.show()
+        self.qpart.text = '  xx'
+        # Move to the end of this string.
+        self.qpart.cursorPosition = (100, 100)
+        # Press home the first time. This should move to the beginning of the
+        # indent: line 0, column 4.
+        self.assertEqual(self.qpart.cursorPosition, (0, 4))
+
+    def column(self):
+        """ Return the column at which the cursor is located."""
+        return self.qpart.cursorPosition[1]
+
+    def test_home2(self):
+        """ Test the operation of the home key. """
+
+        self.qpart.show()
+        self.qpart.text = '\n\n    ' + 'x'*10000
+        # Move to the end of this string.
+        self.qpart.cursorPosition = (100, 100)
+        # Press home. We should either move to the line beginning or indent.
+        QTest.keyClick(self.qpart, Qt.Key_Home)
+        # There's no way I can find of determine what the line beginning should
+        # be. So, just press home again if we're not at the indent.
+        if self.column() != 4:
+            # Press home again to move to the beginning of the indent.
+            QTest.keyClick(self.qpart, Qt.Key_Home)
+        # We're at the indent.
+        self.assertEqual(self.column(), 4)
+
+        # Move to the beginning of the line.
+        QTest.keyClick(self.qpart, Qt.Key_Home)
+        self.assertEqual(self.column(), 0)
+
+        # Move back to the beginning of the indent.
+        QTest.keyClick(self.qpart, Qt.Key_Home)
+        self.assertEqual(self.column(), 4)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should close https://github.com/hlamer/enki/issues/275.

The  first press of home moves to the beginning of the line if it's a multi-line block. After that, old behavior is followed (beginning of indent, beginning of block, back to beginning of indent).