### PR TITLE
Fix: Use the UTF-8 encoding for all file I/O, instead of the default …

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -37,7 +37,7 @@ def main():
 
     import qutepart  # after correct sys.path has been set
 
-    with open(ns.file) as file:
+    with open(ns.file, encoding='utf-8') as file:
         text = file.read()
 
     if ns.debug:

--- a/profiling/typing_performance_test.py
+++ b/profiling/typing_performance_test.py
@@ -18,7 +18,7 @@ print('Language:', q.language())
 
 q.showMaximized()
 
-with open(sys.argv[1]) as file_:
+with open(sys.argv[1], encoding='utf-8') as file_:
     text = file_.read()
 
 clickTimes = {}

--- a/qutepart/syntax/__init__.py
+++ b/qutepart/syntax/__init__.py
@@ -155,7 +155,7 @@ class SyntaxManager:
         self._loadedSyntaxesLock = threading.RLock()
         self._loadedSyntaxes = {}
         syntaxDbPath = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data", "syntax_db.json")
-        with open(syntaxDbPath) as syntaxDbFile:
+        with open(syntaxDbPath, encoding='utf-8') as syntaxDbFile:
             syntaxDb = json.load(syntaxDbFile)
         self._syntaxNameToXmlFileName = syntaxDb['syntaxNameToXmlFileName']
         self._mimeTypeToXmlFileName = syntaxDb['mimeTypeToXmlFileName']

--- a/qutepart/syntax/data/regenerate-definitions-db.py
+++ b/qutepart/syntax/data/regenerate-definitions-db.py
@@ -78,7 +78,7 @@ def main():
     result['extensionToXmlFileName'] = extensionToXmlFileName
     result['firstLineToXmlFileName'] = firstLineToXmlFileName
 
-    with open('syntax_db.json', 'w') as syntaxDbFile:
+    with open('syntax_db.json', 'w', encoding='utf-8') as syntaxDbFile:
         json.dump(result, syntaxDbFile, sort_keys=True, indent=4)
 
     print('Done. Do not forget to commit the changes')

--- a/qutepart/syntax/loader.py
+++ b/qutepart/syntax/loader.py
@@ -536,7 +536,7 @@ def _loadSyntaxDescription(root, syntax):
 
 def loadSyntax(syntax, filePath, formatConverterFunction = None):
     _logger.debug("Loading syntax %s", filePath)
-    with open(filePath, 'r') as definitionFile:
+    with open(filePath, 'r', encoding='utf-8') as definitionFile:
         try:
             root = xml.etree.ElementTree.parse(definitionFile).getroot()
         except Exception as ex:


### PR DESCRIPTION
…platform-dependent encoding.

Otherwise, I see errors like:

======================================================================
ERROR: test_parse_all_definitions (test_syntax.test_xml_definition_parsing.XmlPa
rsingTestCase)
Parse all definitions
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\bjones\Documents\enki_all\qutepart\tests\test_syntax\test_xml_d
efinition_parsing.py", line 25, in test_parse_all_definitions
    syntax = SyntaxManager().getSyntax(None, xmlFileName = xmlFileName)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\__init__.py"
, line 231, in getSyntax
    syntax = self._getSyntaxByXmlFileName(xmlFileName, formatConverterFunction)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\__init__.py"
, line 180, in _getSyntaxByXmlFileName
    qutepart.syntax.loader.loadSyntax(syntax, xmlFilePath, formatConverterFuncti
on)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\loader.py",
line 589, in loadSyntax
    _loadContexts(highlightingElement, syntax.parser, attributeToFormatMap, form
atConverterFunction)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\loader.py",
line 383, in _loadContexts
    _loadContext(context, xmlElement, attributeToFormatMap, formatConverterFunct
ion)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\loader.py",
line 421, in _loadContext
    rules = _loadChildRules(context, xmlElement, attributeToFormatMap, formatCon
verterFunction)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\loader.py",
line 176, in _loadChildRules
    rule = _ruleClassDict[ruleElement.tag](context, ruleElement, attributeToForm
atMap, formatConverterFunction)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\loader.py",
line 152, in _loadIncludeRules
    context = _getContext(contextName, parentContext.parser, formatConverterFunc
tion, parentContext.parser.defaultContext)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\loader.py",
line 110, in _getContext
    parser = parser.syntax.manager.getSyntax(formatConverterFunction, languageNa
me = syntaxName).parser
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\__init__.py"
, line 243, in getSyntax
    syntax = self._getSyntaxByLanguageName(languageName, formatConverterFunction
)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\__init__.py"
, line 188, in _getSyntaxByLanguageName
    return self._getSyntaxByXmlFileName(xmlFileName, formatConverterFunction)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\__init__.py"
, line 180, in _getSyntaxByXmlFileName
    qutepart.syntax.loader.loadSyntax(syntax, xmlFilePath, formatConverterFuncti
on)
  File "C:\Users\bjones\Documents\enki_all\qutepart\qutepart\syntax\loader.py",
line 541, in loadSyntax
    root = xml.etree.ElementTree.parse(definitionFile).getroot()
  File "C:\Users\bjones\Downloads\WinPython-64bit-3.4.3.7Qt5\python-3.4.3.amd64\
lib\xml\etree\ElementTree.py", line 1187, in parse
    tree.parse(source, parser)
  File "C:\Users\bjones\Downloads\WinPython-64bit-3.4.3.7Qt5\python-3.4.3.amd64\
lib\xml\etree\ElementTree.py", line 598, in parse
    self._root = parser._parse_whole(source)
  File "C:\Users\bjones\Downloads\WinPython-64bit-3.4.3.7Qt5\python-3.4.3.amd64\
lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 10209: ch
aracter maps to <undefined>

----------------------------------------------------------------------