### PR TITLE
cParser fix

### DIFF
--- a/qutepart/syntax/cParser.c
+++ b/qutepart/syntax/cParser.c
@@ -1401,7 +1401,7 @@ _WordTree_init(_WordTree* self, PyObject* listOfUnicodeStrings)
         }
     }
 
-    memset(currentWordIndex, 0, sizeof(int) * QUTEPART_MAX_WORD_LENGTH);
+    memset(currentWordIndex, 0, sizeof(Py_ssize_t) * QUTEPART_MAX_WORD_LENGTH);
 
     // second pass, copy data
     for (i = 0; i < totalWordCount; i++)


### PR DESCRIPTION
I recently realized I'd forgotten to recompile qutepart. On my Py3 64 bit Windows PC, tests crash after d93853203baf84e288214d7d5a15a4b6ed6e5b17. This reverts it, plus does some compiler warning cleanup. Would you take a look to make sure I didn't break something?